### PR TITLE
Bump wagmi version to fix Ledger npm package vulnerability

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -40,7 +40,7 @@
         "tailwindcss-animate": "^1.0.6",
         "typescript": "5.2.2",
         "viem": "^1.7.0",
-        "wagmi": "^1.3.10",
+        "wagmi": "^1.4.12",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -229,6 +229,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -271,11 +276,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@ledgerhq/connect-kit-loader": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz",
-      "integrity": "sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A=="
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.2",
@@ -594,6 +594,297 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.3.0.tgz",
+      "integrity": "sha512-pW7QaFiL11O0BphO+bq3MgqeX/INAk9jgBldVDYjlQPO4VddoZnF22TcF9onMhnLVHuNqBJeRf+Fj7eezi/+rQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.3.0",
+        "@parcel/watcher-darwin-arm64": "2.3.0",
+        "@parcel/watcher-darwin-x64": "2.3.0",
+        "@parcel/watcher-freebsd-x64": "2.3.0",
+        "@parcel/watcher-linux-arm-glibc": "2.3.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.3.0",
+        "@parcel/watcher-linux-arm64-musl": "2.3.0",
+        "@parcel/watcher-linux-x64-glibc": "2.3.0",
+        "@parcel/watcher-linux-x64-musl": "2.3.0",
+        "@parcel/watcher-win32-arm64": "2.3.0",
+        "@parcel/watcher-win32-ia32": "2.3.0",
+        "@parcel/watcher-win32-x64": "2.3.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.3.0.tgz",
+      "integrity": "sha512-f4o9eA3dgk0XRT3XhB0UWpWpLnKgrh1IwNJKJ7UJek7eTYccQ8LR7XUWFKqw6aEq5KUNlCcGvSzKqSX/vtWVVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.3.0.tgz",
+      "integrity": "sha512-mKY+oijI4ahBMc/GygVGvEdOq0L4DxhYgwQqYAz/7yPzuGi79oXrZG52WdpGA1wLBPrYb0T8uBaGFo7I6rvSKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.3.0.tgz",
+      "integrity": "sha512-20oBj8LcEOnLE3mgpy6zuOq8AplPu9NcSSSfyVKgfOhNAc4eF4ob3ldj0xWjGGbOF7Dcy1Tvm6ytvgdjlfUeow==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.3.0.tgz",
+      "integrity": "sha512-7LftKlaHunueAEiojhCn+Ef2CTXWsLgTl4hq0pkhkTBFI3ssj2bJXmH2L67mKpiAD5dz66JYk4zS66qzdnIOgw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.3.0.tgz",
+      "integrity": "sha512-1apPw5cD2xBv1XIHPUlq0cO6iAaEUQ3BcY0ysSyD9Kuyw4MoWm1DV+W9mneWI+1g6OeP6dhikiFE6BlU+AToTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.3.0.tgz",
+      "integrity": "sha512-mQ0gBSQEiq1k/MMkgcSB0Ic47UORZBmWoAWlMrTW6nbAGoLZP+h7AtUM7H3oDu34TBFFvjy4JCGP43JlylkTQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.3.0.tgz",
+      "integrity": "sha512-LXZAExpepJew0Gp8ZkJ+xDZaTQjLHv48h0p0Vw2VMFQ8A+RKrAvpFuPVCVwKJCr5SE+zvaG+Etg56qXvTDIedw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.3.0.tgz",
+      "integrity": "sha512-P7Wo91lKSeSgMTtG7CnBS6WrA5otr1K7shhSjKHNePVmfBHDoAOHYRXgUmhiNfbcGk0uMCHVcdbfxtuiZCHVow==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.3.0.tgz",
+      "integrity": "sha512-+kiRE1JIq8QdxzwoYY+wzBs9YbJ34guBweTK8nlzLKimn5EQ2b2FSC+tAOpq302BuIMjyuUGvBiUhEcLIGMQ5g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-wasm": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.3.0.tgz",
+      "integrity": "sha512-ejBAX8H0ZGsD8lSICDNyMbSEtPMWgDL0WFCt/0z7hyf5v8Imz4rAM8xY379mBsECkq/Wdqa5WEDLqtjZ+6NxfA==",
+      "bundleDependencies": [
+        "napi-wasm"
+      ],
+      "dependencies": {
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "napi-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.3.0.tgz",
+      "integrity": "sha512-35gXCnaz1AqIXpG42evcoP2+sNL62gZTMZne3IackM+6QlfMcJLy3DrjuL6Iks7Czpd3j4xRBzez3ADCj1l7Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.3.0.tgz",
+      "integrity": "sha512-FJS/IBQHhRpZ6PiCjFt1UAcPr0YmCLHRbTc00IBTrelEjlmmgIVLeOx4MSXzx2HFEy5Jo5YdhGpxCuqCyDJ5ow==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.3.0.tgz",
+      "integrity": "sha512-dLx+0XRdMnVI62kU3wbXvbIRhLck4aE28bIGKbRGS7BJNt54IIj9+c/Dkqb+7DJEbHUZAX1bwaoM8PqVlHJmCA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/node-addon-api": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.0.1",
@@ -1135,21 +1426,12 @@
       "integrity": "sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA=="
     },
     "node_modules/@safe-global/safe-apps-provider": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.17.1.tgz",
-      "integrity": "sha512-lYfRqrbbK1aKU1/UGkYWc/X7PgySYcumXKc5FB2uuwAs2Ghj8uETuW5BrwPqyjBknRxutFbTv+gth/JzjxAhdQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.1.tgz",
+      "integrity": "sha512-V4a05A3EgJcriqtDoJklDz1BOinWhC6P0hjUSxshA4KOZM7rGPCTto/usXs09zr1vvL28evl/NldSTv97j2bmg==",
       "dependencies": {
-        "@safe-global/safe-apps-sdk": "8.0.0",
+        "@safe-global/safe-apps-sdk": "^8.1.0",
         "events": "^3.3.0"
-      }
-    },
-    "node_modules/@safe-global/safe-apps-provider/node_modules/@safe-global/safe-apps-sdk": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.0.0.tgz",
-      "integrity": "sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==",
-      "dependencies": {
-        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
-        "viem": "^1.0.0"
       }
     },
     "node_modules/@safe-global/safe-apps-sdk": {
@@ -1162,9 +1444,9 @@
       }
     },
     "node_modules/@safe-global/safe-gateway-typescript-sdk": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.12.0.tgz",
-      "integrity": "sha512-hExCo62lScVC9/ztVqYEYL2pFxcqLTvB8fj0WtdP5FWrvbtEgD0pbVolchzD5bf85pbzvEwdAxSVS7EdCZxTNw==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.13.3.tgz",
+      "integrity": "sha512-qBDM469cVCedpBpeTSn+k5FUr9+rq5bMTflp/mKd7h35uafcexvOR/PHZn2qftqV8b1kc9b8t22cPRJ2365jew==",
       "engines": {
         "node": ">=16"
       }
@@ -1214,11 +1496,11 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.87.1",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.1.tgz",
-      "integrity": "sha512-E8Y9bNlZ8TQlhOvCx1b7jG+TjA4SJLVwufmIk1+tcQctUhK5HiB1Q8ljd4yQDkFlk6OOeAlAeqvW0YntWJU94Q==",
+      "version": "1.87.6",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.6.tgz",
+      "integrity": "sha512-LkqsEBgTZztFiccZZXnawWa8qNCATEqE97/d0vIwjTclmVlc8pBpD1DmjfVHtZ1HS5fZorFlVhXfpwnCNDZfyg==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.2",
         "@noble/curves": "^1.2.0",
         "@noble/hashes": "^1.3.1",
         "@solana/buffer-layout": "^4.0.0",
@@ -1464,17 +1746,17 @@
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.37",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.37.tgz",
-      "integrity": "sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
-      "integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -1491,9 +1773,9 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/ms": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
-      "integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ=="
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
       "version": "20.5.6",
@@ -1534,9 +1816,9 @@
       "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw=="
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.5.tgz",
-      "integrity": "sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -1683,9 +1965,9 @@
       }
     },
     "node_modules/@wagmi/connectors": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-3.1.2.tgz",
-      "integrity": "sha512-IlLKErqCzQRBUcCvXGPowcczbWcvJtEG006gPsAoePNJEXCHEWoKASghgu+L/bqD7006Z6mW6zlTNjcSQJvFAg==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-3.1.10.tgz",
+      "integrity": "sha512-ZLJC1QaeiZarkF07Cr9mOlVjPO1Lf5TBx+JKBms2y5fUIXlKrxCfQgO/gDCureboI+Us2X3IRI659+XacSGpbA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -1698,13 +1980,12 @@
       ],
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.6.6",
-        "@ledgerhq/connect-kit-loader": "^1.1.0",
-        "@safe-global/safe-apps-provider": "^0.17.1",
-        "@safe-global/safe-apps-sdk": "^8.0.0",
-        "@walletconnect/ethereum-provider": "2.10.1",
+        "@safe-global/safe-apps-provider": "^0.18.1",
+        "@safe-global/safe-apps-sdk": "^8.1.0",
+        "@walletconnect/ethereum-provider": "2.10.6",
         "@walletconnect/legacy-provider": "^2.0.0",
         "@walletconnect/modal": "2.6.2",
-        "@walletconnect/utils": "2.10.1",
+        "@walletconnect/utils": "2.10.2",
         "abitype": "0.8.7",
         "eventemitter3": "^4.0.7"
       },
@@ -1733,9 +2014,9 @@
       }
     },
     "node_modules/@wagmi/core": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-1.4.4.tgz",
-      "integrity": "sha512-38Pa5iH9/2zHX837vYm6M+c//BBikt6vKJqUiEgkIzSqFvlfzbxaNmwybpIxl98N5r+X22C3yHv5bboO9eP0vQ==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-1.4.12.tgz",
+      "integrity": "sha512-bLcYmmGgjtl3jAGo8X3Sm6oUwsdjbVxFMu9SWnwHdE4S9JdYeWM57dEhQgq8SYul2yQ7yY2/gimBf1Or0Ky3dQ==",
       "funding": [
         {
           "type": "gitcoin",
@@ -1747,7 +2028,7 @@
         }
       ],
       "dependencies": {
-        "@wagmi/connectors": "3.1.2",
+        "@wagmi/connectors": "3.1.10",
         "abitype": "0.8.7",
         "eventemitter3": "^4.0.7",
         "zustand": "^4.3.1"
@@ -1777,26 +2058,64 @@
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.1.tgz",
-      "integrity": "sha512-WAoXfmj+Zy5q48TnrKUjmHXJCBahzKwbul+noepRZf7JDtUAZ9IOWpUjg+UPRbfK5EiWZ0TF42S6SXidf7EHoQ==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.6.tgz",
+      "integrity": "sha512-Z4vh4ZdfcoQjgPEOxeuF9HUZCVLtV3MgRbS/awLIj/omDrFnOwlBhxi5Syr4Y8muVGC0ocRetQYHae0/gX5crQ==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.13",
-        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.14",
+        "@walletconnect/keyvaluestorage": "^1.1.1",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.1",
-        "@walletconnect/utils": "2.10.1",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/utils": {
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.6.tgz",
+      "integrity": "sha512-oRsWWhN2+hi3aiDXrQEOfysz6FHQJGXLsNQPVt+WIBJplO6Szmdau9dbleD88u1iiT4GKPqE0R9FOYvvPm1H/w==",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@walletconnect/crypto": {
@@ -1851,27 +2170,58 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/ethereum-provider": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.10.1.tgz",
-      "integrity": "sha512-Yhoz8EXkKzxOlBT6G+elphqCx/gkH6RxD9/ZAiy9lLc8Ng5p1gvKCVVP5zsGNE9FbkKmHd+J9JJRzn2Bw2yqtQ==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.10.6.tgz",
+      "integrity": "sha512-bBQ+yUfxLv8VxNttgNKY7nED35gSVayO/BnLHbNKvyV1gpvSCla5mWB9MsXuQs70MK0g+/qtgRVSrOtdSubaNQ==",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/sign-client": "2.10.1",
-        "@walletconnect/types": "2.10.1",
-        "@walletconnect/universal-provider": "2.10.1",
-        "@walletconnect/utils": "2.10.1",
+        "@walletconnect/modal": "^2.4.3",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/universal-provider": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/utils": {
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.6.tgz",
+      "integrity": "sha512-oRsWWhN2+hi3aiDXrQEOfysz6FHQJGXLsNQPVt+WIBJplO6Szmdau9dbleD88u1iiT4GKPqE0R9FOYvvPm1H/w==",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       },
-      "peerDependencies": {
-        "@walletconnect/modal": ">=2"
+      "engines": {
+        "node": ">=6"
       },
-      "peerDependenciesMeta": {
-        "@walletconnect/modal": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@walletconnect/events": {
@@ -1964,21 +2314,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
-      "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
         "events": "^3.3.0",
-        "tslib": "1.14.1",
         "ws": "^7.5.1"
       }
-    },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.9",
@@ -2001,30 +2345,22 @@
       }
     },
     "node_modules/@walletconnect/keyvaluestorage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz",
-      "integrity": "sha512-U/nNG+VLWoPFdwwKx0oliT4ziKQCEoQ27L5Hhw8YOFGA2Po9A9pULUYNWhDgHkrb0gYDNt//X7wABcEWWBd3FQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
       "dependencies": {
-        "safe-json-utils": "^1.1.1",
-        "tslib": "1.14.1"
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
       },
       "peerDependencies": {
-        "@react-native-async-storage/async-storage": "1.x",
-        "lokijs": "1.x"
+        "@react-native-async-storage/async-storage": "1.x"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
           "optional": true
-        },
-        "lokijs": {
-          "optional": true
         }
       }
-    },
-    "node_modules/@walletconnect/keyvaluestorage/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/legacy-client": {
       "version": "2.0.0",
@@ -2229,19 +2565,57 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.10.1.tgz",
-      "integrity": "sha512-iG3eJGi1yXeG3xGeVSSMf8wDFyx239B0prLQfy1uYDtYFb2ynnH/09oqAZyKn96W5nfQzUgM2Mz157PVdloH3Q==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.10.6.tgz",
+      "integrity": "sha512-EvUWjaZBQu2yKnH5/5F2qzbuiIuUN9ZgrNKgvXkw5z1Dq5RJCks0S9/MFlKH/ZSGqXnLl7uAzBXtoX4sMgbCMA==",
       "dependencies": {
-        "@walletconnect/core": "2.10.1",
+        "@walletconnect/core": "2.10.6",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.1",
-        "@walletconnect/utils": "2.10.1",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/utils": {
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.6.tgz",
+      "integrity": "sha512-oRsWWhN2+hi3aiDXrQEOfysz6FHQJGXLsNQPVt+WIBJplO6Szmdau9dbleD88u1iiT4GKPqE0R9FOYvvPm1H/w==",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@walletconnect/time": {
@@ -2258,38 +2632,38 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.1.tgz",
-      "integrity": "sha512-7pccAhajQdiH2kYywjE1XI64IqRI+4ioyGy0wvz8d0UFQ/DSG3MLKR8jHf5aTOafQQ/HRLz6xvlzN4a7gIVkUQ==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.6.tgz",
+      "integrity": "sha512-WgHfiTG1yakmxheaBRiXhUdEmgxwrvsAdOIWaMf/spvrzVKYh6sHI3oyEEky5qj5jjiMiyQBeB57QamzCotbcQ==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-types": "1.0.3",
-        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/keyvaluestorage": "^1.1.1",
         "@walletconnect/logger": "^2.0.1",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/universal-provider": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.10.1.tgz",
-      "integrity": "sha512-81QxTH/X4dRoYCz0U9iOrBYOcj7N897ONcB57wsGhEkV7Rc9htmWJq2CzeOuxvVZ+pNZkE+/aw9LrhizO1Ltxg==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.10.6.tgz",
+      "integrity": "sha512-CEivusqqoD31BhCTKp08DnrccfGjwD9MFjZs5BNRorDteRFE8zVm9LmP6DSiNJCw82ZajGlZThggLQ/BAATfwA==",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.10.1",
-        "@walletconnect/types": "2.10.1",
-        "@walletconnect/utils": "2.10.1",
+        "@walletconnect/sign-client": "2.10.6",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0"
       }
     },
-    "node_modules/@walletconnect/utils": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.1.tgz",
-      "integrity": "sha512-DM0dKgm9O58l7VqJEyV2OVv16XRePhDAReI23let6WdW1dSpw/Y/A89Lp99ZJOjLm2FxyblMRF3YRaZtHwBffw==",
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.6.tgz",
+      "integrity": "sha512-oRsWWhN2+hi3aiDXrQEOfysz6FHQJGXLsNQPVt+WIBJplO6Szmdau9dbleD88u1iiT4GKPqE0R9FOYvvPm1H/w==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -2299,12 +2673,63 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.1",
+        "@walletconnect/types": "2.10.6",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
         "query-string": "7.1.3",
         "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.2.tgz",
+      "integrity": "sha512-syxXRpc2yhSknMu3IfiBGobxOY7fLfLTJuw+ppKaeO6WUdZpIit3wfuGOcc0Ms3ZPFCrGfyGOoZsCvgdXtptRg==",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.10.2",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.2.tgz",
+      "integrity": "sha512-luNV+07Wdla4STi9AejseCQY31tzWKQ5a7C3zZZaRK/di+rFaAAb7YW04OP4klE7tw/mJRGPTlekZElmHxO8kQ==",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/query-string": {
@@ -2479,6 +2904,25 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -3024,6 +3468,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/citty": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.5.tgz",
+      "integrity": "sha512-AS7n5NSc0OQVMV9v6wt3ByujNIrne0/cTjiC2MYqhvao57VNfiuVksTSr2p17nVOhEr2KtqiAkGwHcgMC/qUuQ==",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
@@ -3039,6 +3491,22 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "6.0.0",
@@ -3056,6 +3524,14 @@
       "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -3092,6 +3568,19 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.0.0.tgz",
+      "integrity": "sha512-mWYvfOLrfEc996hlKcdABeIiPHUPC6DM2QYZdGGOvhOTbA3tjm2eBwqlJpoFdjC89NI4Qt6h0Pu06Mp+1Pj5OQ=="
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -3257,6 +3746,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.3.tgz",
+      "integrity": "sha512-Vy2wmG3NTkmHNg/kzpuvHhkqeIx3ODWqasgCRbKtbXEN0G+HpEEv9BtJLp7ZG1CZloFaC41Ah3ZFbq7aqCqMeQ=="
+    },
     "node_modules/delay": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
@@ -3268,6 +3762,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3276,10 +3778,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/destr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.2.tgz",
+      "integrity": "sha512-65AlobnZMiCET00KaFFjUefxDX0khFA/E4myqZ7a6Sq1yZtR8+FVIvilVX66vF2uobSumxooYZChiRPCKNqhmg=="
+    },
     "node_modules/detect-browser": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
       "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+    },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -4086,6 +4604,28 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -4336,6 +4876,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.1.tgz",
+      "integrity": "sha512-3UBAyM3u4ZBVYDsxOQfJDxEa6XTbpBDrOjp4mf7ExFRt5BKs/QywQQiJsh2B+hxcZLSapWqCRvElUe8DnKcFHA=="
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -4464,6 +5020,21 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+    },
+    "node_modules/h3": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.9.0.tgz",
+      "integrity": "sha512-+F3ZqrNV/CFXXfZ2lXBINHi+rM4Xw3CDC5z2CDK3NMPocjonKipGLLDSkrqY9DOrioZNPTIdDMWfQKm//3X2DA==",
+      "dependencies": {
+        "cookie-es": "^1.0.0",
+        "defu": "^6.1.3",
+        "destr": "^2.0.2",
+        "iron-webcrypto": "^1.0.0",
+        "radix3": "^1.1.0",
+        "ufo": "^1.3.2",
+        "uncrypto": "^0.1.3",
+        "unenv": "^1.7.4"
+      }
     },
     "node_modules/has": {
       "version": "1.0.4",
@@ -4614,6 +5185,23 @@
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
+    "node_modules/http-shutdown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
+      "integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -4643,6 +5231,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -4727,6 +5320,37 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.0.0.tgz",
+      "integrity": "sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-arguments": {
@@ -4842,6 +5466,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -4979,6 +5617,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -5055,6 +5704,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -5237,6 +5897,11 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -5352,6 +6017,34 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/listhen": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.5.5.tgz",
+      "integrity": "sha512-LXe8Xlyh3gnxdv4tSjTjscD1vpr/2PRpzq8YIaMJgyKzRG8wdISlWVWnGThJfHnlJ6hmLt2wq1yeeix0TEbuoA==",
+      "dependencies": {
+        "@parcel/watcher": "^2.3.0",
+        "@parcel/watcher-wasm": "2.3.0",
+        "citty": "^0.1.4",
+        "clipboardy": "^3.0.0",
+        "consola": "^3.2.3",
+        "defu": "^6.1.2",
+        "get-port-please": "^3.1.1",
+        "h3": "^1.8.1",
+        "http-shutdown": "^1.2.2",
+        "jiti": "^1.20.0",
+        "mlly": "^1.4.2",
+        "node-forge": "^1.3.1",
+        "pathe": "^1.1.1",
+        "std-env": "^3.4.3",
+        "ufo": "^1.3.0",
+        "untun": "^0.1.2",
+        "uqr": "^0.1.2"
+      },
+      "bin": {
+        "listen": "bin/listhen.mjs",
+        "listhen": "bin/listhen.mjs"
+      }
+    },
     "node_modules/lit": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
@@ -5399,6 +6092,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -5413,7 +6116,7 @@
       "version": "1.5.12",
       "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.12.tgz",
       "integrity": "sha512-Q5ALD6JiS6xAUWCwX3taQmgwxyveCtIIuL08+ml0nHwT3k0S/GIFJN+Hd38b1qYIMaE5X++iqsqWVksz7SYW+Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5458,6 +6161,11 @@
         "@babel/runtime": "^7.12.5"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5476,6 +6184,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -5502,6 +6229,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
+      "integrity": "sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==",
+      "dependencies": {
+        "acorn": "^8.10.0",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.0"
+      }
+    },
     "node_modules/motion": {
       "version": "10.16.2",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
@@ -5513,6 +6251,14 @@
         "@motionone/types": "^10.15.1",
         "@motionone/utils": "^10.15.1",
         "@motionone/vue": "^10.16.2"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -5658,6 +6404,19 @@
         }
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.4.1.tgz",
+      "integrity": "sha512-NsXBU0UgBxo2rQLOeWNZqS3fvflWePMECr8CoSWoSTqCqGbVVsvl9vZu1HfQicYN0g5piV9Gh8RTEvo/uP752w=="
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
@@ -5687,6 +6446,17 @@
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -5806,6 +6576,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ofetch": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.3.3.tgz",
+      "integrity": "sha512-s1ZCMmQWXy4b5K/TW9i/DtiN8Ku+xCiHcjQ6/J/nDdssirrQNOoB165Zu8EqLMA2lln1JUth9a0aW9Ap2ctrUg==",
+      "dependencies": {
+        "destr": "^2.0.1",
+        "node-fetch-native": "^1.4.0",
+        "ufo": "^1.3.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -5821,6 +6601,20 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -5927,6 +6721,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -6041,6 +6840,16 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
       }
     },
     "node_modules/pngjs": {
@@ -6176,9 +6985,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.18.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.18.1.tgz",
-      "integrity": "sha512-mKUD7RRkQQM6s7Rkmi7IFkoEHjuFqRQUaXamO61E6Nn7vqF/bo7EZCmSyrUnp2UWHw0O7XjZ2eeXis+m7tf4lg==",
+      "version": "10.19.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+      "integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6398,6 +7207,11 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
+    "node_modules/radix3": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.0.tgz",
+      "integrity": "sha512-pNsHDxbGORSvuSScqNJ+3Km6QAVqk8CfsCBIEoDgpqLrkD2f3QM4I7d1ozJJ172OmIcoUcerZaNWqtLkRXTV3A=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6564,6 +7378,25 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -6673,9 +7506,9 @@
       }
     },
     "node_modules/rpc-websockets": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.6.1.tgz",
-      "integrity": "sha512-MmRGaJJvxTHSRxYPjJJqcj2zWnCetw7YbYbKlD0Yc7qVw6PsZhRJg1MI3mpWlpBs+4zO+urlNfLl9zLsdOD/gA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.8.0.tgz",
+      "integrity": "sha512-AStkq6KDvSAmA4WiwlK1pDvj/33BWmExTATUokC0v+NhWekXSTNzXS5OGXeYwq501/pj6lBZMofg/h4dx4/tCg==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "eventemitter3": "^4.0.7",
@@ -6764,11 +7597,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/safe-json-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -6887,6 +7715,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6927,6 +7760,16 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
+    "node_modules/std-env": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.6.0.tgz",
+      "integrity": "sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg=="
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -7075,6 +7918,14 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -7448,6 +8299,11 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+      "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA=="
+    },
     "node_modules/uint8arrays": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -7468,6 +8324,114 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+    },
+    "node_modules/unenv": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.8.0.tgz",
+      "integrity": "sha512-uIGbdCWZfhRRmyKj1UioCepQ0jpq638j/Cf0xFTn4zD1nGJ2lSdzYHLzfdXN791oo/0juUiSWW1fBklXMTsuqg==",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "defu": "^6.1.3",
+        "mime": "^3.0.0",
+        "node-fetch-native": "^1.4.1",
+        "pathe": "^1.1.1"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.10.1.tgz",
+      "integrity": "sha512-rWQvLRfZNBpF+x8D3/gda5nUCQL2PgXy2jNG4U7/Rc9BGEv9+CAJd0YyGCROUBKs9v49Hg8huw3aih5Bf5TAVw==",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^3.5.3",
+        "destr": "^2.0.2",
+        "h3": "^1.8.2",
+        "ioredis": "^5.3.2",
+        "listhen": "^1.5.5",
+        "lru-cache": "^10.0.2",
+        "mri": "^1.2.0",
+        "node-fetch-native": "^1.4.1",
+        "ofetch": "^1.3.3",
+        "ufo": "^1.3.1"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.4.1",
+        "@azure/cosmos": "^4.0.0",
+        "@azure/data-tables": "^13.2.2",
+        "@azure/identity": "^3.3.2",
+        "@azure/keyvault-secrets": "^4.7.0",
+        "@azure/storage-blob": "^12.16.0",
+        "@capacitor/preferences": "^5.0.6",
+        "@netlify/blobs": "^6.2.0",
+        "@planetscale/database": "^1.11.0",
+        "@upstash/redis": "^1.23.4",
+        "@vercel/kv": "^0.2.3",
+        "idb-keyval": "^6.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/untun": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/untun/-/untun-0.1.2.tgz",
+      "integrity": "sha512-wLAMWvxfqyTiBODA1lg3IXHQtjggYLeTK7RnSfqtOXixWJ3bAa2kK/HHmOOg19upteqO3muLvN6O/icbyQY33Q==",
+      "dependencies": {
+        "citty": "^0.1.3",
+        "consola": "^3.2.3",
+        "pathe": "^1.1.1"
+      },
+      "bin": {
+        "untun": "bin/untun.mjs"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -7498,6 +8462,11 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uqr": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
+      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -7673,9 +8642,9 @@
       }
     },
     "node_modules/wagmi": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-1.4.4.tgz",
-      "integrity": "sha512-uT6GRNrw3WTrdVRQ7wAHiQL2/gaqaUjcEeHRwsbiqrAT9ZfVtZw7uhl+ZueLpem2zFxlR2zhnRMNbAOKD0IcEA==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-1.4.12.tgz",
+      "integrity": "sha512-QRxpjhdMlZmbYTfn9VQkQMKq+l3kwA1O7tF10vaykPrjbGX+IIlyn72ib9oqW9BfQO7n/Sf/mnVz1zbxRhGPWA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -7690,7 +8659,7 @@
         "@tanstack/query-sync-storage-persister": "^4.27.1",
         "@tanstack/react-query": "^4.28.0",
         "@tanstack/react-query-persist-client": "^4.28.0",
-        "@wagmi/core": "1.4.4",
+        "@wagmi/core": "1.4.12",
         "abitype": "0.8.7",
         "use-sync-external-store": "^1.2.0"
       },
@@ -8001,9 +8970,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.3.tgz",
-      "integrity": "sha512-oRy+X3ZazZvLfmv6viIaQmtLOMeij1noakIsK/Y47PWYhT8glfXzQ4j0YcP5i0P0qI1A4rIB//SGROGyZhx91A==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.7.tgz",
+      "integrity": "sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -41,7 +41,7 @@
     "tailwindcss-animate": "^1.0.6",
     "typescript": "5.2.2",
     "viem": "^1.7.0",
-    "wagmi": "^1.3.10",
+    "wagmi": "^1.4.12",
     "zod": "^3.22.2"
   },
   "devDependencies": {


### PR DESCRIPTION
 - bumps wagmi version to the latest one that removes vulnerable @ledgerhq/connect-kit-loader package version

Ref: https://github.com/wevm/wagmi/releases/tag/wagmi%401.4.12